### PR TITLE
feat!: adopt mod-utils v6 (mod-lottie v3)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@
     source = 'data'
     target = 'data'
   [[module.imports]]
-    path = "github.com/gethinode/mod-utils/v5"
+    path = "github.com/gethinode/mod-utils/v6"
 
 [params.modules.lottie]
   integration = "optional"

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -6,8 +6,12 @@ date: 2023-09-29
 
 ## Animate automatically
 
-{{< animation animation-data="adrock.json" loop=true >}}
+{{< animation animation-data="adrock.json" loop=true autoplay=true >}}
 
 ## Animate on hover
 
 {{< animation animation-data="gatin.json" autoplay=false hover=true loop=false >}}
+
+## Animate automatically using the deprecated auto argument
+
+{{< animation animation-data="adrock.json" loop=true auto=true >}}

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -3,9 +3,9 @@ languageCode = 'en-us'
 title = 'Test site for mod-lottie'
 
 [module]
-  replacements = 'github.com/gethinode/mod-lottie -> ../..'
+  replacements = 'github.com/gethinode/mod-lottie/v3 -> ../..'
   [[module.imports]]
-    path = "github.com/gethinode/mod-lottie"
+    path = "github.com/gethinode/mod-lottie/v3"
   [[module.imports.mounts]]
     source = "assets"
     target = "assets"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/gethinode/mod-lottie/v2
+module github.com/gethinode/mod-lottie/v3
 
 go 1.19
 
 require (
 	github.com/airbnb/lottie-web v5.13.0+incompatible // indirect
-	github.com/gethinode/mod-utils/v5 v5.23.4 // indirect
+	github.com/gethinode/mod-utils/v6 v6.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -168,3 +168,5 @@ github.com/gethinode/mod-utils/v5 v5.23.3 h1:ifcDyTYpmM6HBzc6SbpG+hJMSCfGTZKf/pl
 github.com/gethinode/mod-utils/v5 v5.23.3/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
 github.com/gethinode/mod-utils/v5 v5.23.4 h1:/lcKi1MJ2srGfNhCPtdnTRpQgdh2FNBRUAS7Ysz1W34=
 github.com/gethinode/mod-utils/v5 v5.23.4/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
+github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
+github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/layouts/partials/assets/animation.html
+++ b/layouts/partials/assets/animation.html
@@ -21,30 +21,41 @@
         {{- $data = partial "utilities/GetStaticURL" (dict "url" $data) -}}
         <div id="{{ $id }}" class="lottie-animation{{ with $class}} {{ . }}{{ end }}"
             {{ with $loop }}data-lottie-loop="{{ . }}"{{ end }}
-            {{ if ne $auto nil }}data-lottie-auto="{{ $auto }}"{{ end }}
-            {{ if ne $hover nil }}data-lottie-hover="{{ $hover }}"{{ end }}
+            data-lottie-auto="{{ $auto }}"
+            data-lottie-hover="{{ $hover }}"
             {{ with $title }}data-lottie-title="{{ . }}"{{ end }}
             {{ with $data }}data-lottie-data="{{ . }}"{{ end }}>
         </div>
     {{- end -}}
 {{- end -}}
 
-{{/* Initialize arguments */}}
-{{ $args := partial "utilities/InitArgs.html" (dict "structure" "animation" "args" . "group" "partial") }}
-{{ if or $args.err $args.warnmsg }}
-    {{ partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
-        "partial" "assets/animation.html" 
+{{/*
+    Initialize arguments. This partial is a public entry point that can be invoked directly by
+    Hinode and other modules with values sourced from page content, so it validates non-strict
+    like a site-authored-content entry point.
+*/}}
+{{ $result := partial "utilities/Args.html" (dict "structure" "animation" "args" . "group" "partial" "strict" false) }}
+{{ $args := $result.args }}
+{{ if or $result.err $result.warnmsg }}
+    {{ partial (cond $result.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial" "assets/animation.html"
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
-        "details" ($args.errmsg | append $args.warnmsg)
+        "details" ($result.errmsg | append $result.warnmsg)
         "file"    page.File
     )}}
-    {{ $error = $args.err }}
+    {{ $error = $result.err }}
 {{ end }}
 
-{{/* Initialize local arguments */}}
+{{/*
+    Initialize local arguments. The "autoplay" and "hover" arguments always carry schema defaults
+    (false), so neither is nil by the time it reaches here. Only fall back to the deprecated
+    "auto" argument when the caller genuinely left "autoplay" unset (per $result.defaulted);
+    otherwise a caller's explicit autoplay=false would be silently overridden by a stale
+    deprecated value.
+*/}}
 {{- $auto := $args.autoplay -}}
-{{- if eq $auto nil -}}
+{{- if and (in $result.defaulted "autoplay") (ne $args.auto nil) -}}
     {{- $auto = $args.auto -}}
 {{- end -}}
 {{- $hover := $args.hover -}}

--- a/layouts/shortcodes/animation.html
+++ b/layouts/shortcodes/animation.html
@@ -6,18 +6,22 @@
 
 {{ $error := false }}
 
-{{/* Validate and initialize arguments */}}
-{{ $args := partial "utilities/InitArgs.html" (dict "structure" "animation" "args" .Params "named" .IsNamedParams "group" "shortcode") }}
-{{ if or $args.err $args.warnmsg }}
-    {{ partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
-        "partial"  "shortcodes/animation.html" 
+{{/*
+    Validate and initialize arguments. This shortcode is a user-facing content entry point, so it
+    validates non-strict (warnings-first rollout for site-authored inputs).
+*/}}
+{{ $result := partial "utilities/Args.html" (dict "structure" "animation" "args" .Params "named" .IsNamedParams "group" "shortcode" "strict" false) }}
+{{ $args := $result.args }}
+{{ if or $result.err $result.warnmsg }}
+    {{ partial (cond $result.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial"  "shortcodes/animation.html"
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
-        "details"  ($args.errmsg | append $args.warnmsg)
+        "details"  ($result.errmsg | append $result.warnmsg)
         "file"     page.File
         "position" .Position
     )}}
-    {{ $error = $args.err }}
+    {{ $error = $result.err }}
 {{ end }}
 
 {{/* Initialize arguments and default values */}}
@@ -55,8 +59,14 @@
 
 <!-- Main code -->
 {{- if not $error -}}
+    {{/*
+        The "autoplay" argument always carries a schema default of false, so it is never nil by
+        the time it reaches here. Only fall back to the deprecated "auto" argument when the
+        caller genuinely left "autoplay" unset (per $result.defaulted); otherwise a caller's
+        explicit autoplay=false would be silently overridden by a stale deprecated value.
+    */}}
     {{- $autoplay := $args.autoplay -}}
-    {{- if eq $autoplay nil -}}
+    {{- if and (in $result.defaulted "autoplay") (ne $args.auto nil) -}}
         {{- $autoplay = $args.auto -}}
     {{- end -}}
     {{ partial "assets/animation.html" (dict


### PR DESCRIPTION
## Summary

Adopts [mod-utils v6](https://github.com/gethinode/mod-utils/releases/tag/v6.0.1) (gethinode/mod-utils#334), the argument/type validation engine redesign, as this module's own major release (v2 → v3). Part of the [mod-utils v6 adoption program](https://github.com/gethinode/hinode/blob/main/docs/superpowers/specs/2026-07-12-mod-utils-v6-adoption-program-driver.md) (wave 1).

- **Go path bump:** `github.com/gethinode/mod-lottie/v2` → `/v3`; `mod-utils` requirement bumped to `v6.0.1` (never `v6.0.0`, which carries a camelKey defaulting defect fixed in `6.0.1`).
- **Hugo config / self-references:** `config.toml` (mod-utils import) and `exampleSite/hugo.toml` (bare `replacements` + import path, this exampleSite's wiring) updated to the new majors. No versioned references remained in `README.md`.
- **Argument handling migrated to `Args.html`** (see the [v5-to-v6 migration notes](https://github.com/gethinode/mod-utils/blob/main/README.md#migrating-from-v5-to-v6)), with the strict-false guardrail on both call sites — both accept site-authored values:
  - `layouts/shortcodes/animation.html`
  - `layouts/partials/assets/animation.html` (public partial invocable directly by Hinode/other modules with page-content-derived values, so also validated non-strict)

### Call-site fixes carried in this PR (recipe step 5c)

1. **Dead deprecated-argument fallback (real behavior bug).** The `autoplay` argument carries a schema default of `false`. Under the old engine that falsy default was silently ignored, leaving `$args.autoplay` `nil` when unset — so both call sites did `{{ if eq $autoplay nil }}{{ $autoplay = $args.auto }}{{ end }}` to fall back to the deprecated `auto` argument (whose own inline default was `true`). Under v6, `autoplay`'s default is now correctly applied (never `nil`), **and** v6 correctly strips `default`/`config` from any node marked `deprecated` — so this fallback chain silently went dead in two directions at once. Fixed by checking the new envelope's `defaulted` list: the deprecated-argument fallback now only fires when `autoplay` was genuinely left unset by the caller, and an explicit `autoplay=false` is honored either way. Confirmed via HTML-source diff (see below) that both the canonical and deprecated paths produce the expected `data-lottie-auto` value.
2. **Dead nil-guards on rendered attributes.** `assets/animation.html`'s `animation-body` partial guarded `data-lottie-auto`/`data-lottie-hover` output with `{{ if ne $auto/$hover nil }}`, a workaround for the old broken falsy-default behavior. Both values are now always boolean (never `nil`), so the guard was permanently true; removed it and render the attributes unconditionally. `lottie.player.js` reads a missing attribute the same as `"false"` (`String(el.getAttribute(...)).toLowerCase() === 'true'`), so this is a rendered-markup-only change with no runtime behavior difference — verified via HTML-source diff per the program's pixel-diff-is-not-proof-for-attributes refinement.

### exampleSite content (recipe step 4d exercise gate)

- The first demo (`## Animate automatically`) relied on the deprecated `auto` argument's default to actually autoplay — a latent coupling on now-corrected deprecated-argument behavior. Made it explicit with `autoplay=true` so its rendered behavior survives the corrected defaulting semantics.
- Added a third demo (`## Animate automatically using the deprecated auto argument`) using `auto=true` with `autoplay` unset, to exercise the deprecated-argument fallback fix above end to end (and its expected deprecation warning).

## Test plan

- [x] `hugo mod graph` (exampleSite context) shows `github.com/gethinode/mod-utils/v6@v6.0.1+vendor`, zero `/v5` references anywhere in the graph
- [x] `pnpm build` (`hugo --gc --minify -s exampleSite`) exits 0 with zero ERROR lines
- [x] Only one WARN line attributable to this module's own shortcode/partial: the intentional deprecation warning from the new `auto=true` demo (`[animation] argument 'auto': deprecated in v1.0.0, use 'autoplay' instead`) — expected, not a bug. The other three WARN lines (`languageCode` deprecated, `.Site.Data` deprecated, `Processing js pattern`) are pre-existing Hugo-core/config warnings, unchanged from the pre-migration baseline build.
- [x] Every migrated call site exercised by the exampleSite: both demos exercise the shortcode → partial chain; the three demos together cover explicit `autoplay=true`/`false`, explicit `hover=true`, explicit `loop=true`/`false`, and the deprecated `auto=true` fallback
- [x] Visual regression: own exampleSite shot before/after (harness: `tests/visual/` on the hinode `program/mod-utils-v6-adoption` branch), 3 pages compared, 1 flagged (`index.png`, 0.281%) — triaged **intended**: the diff image shows only the new third-demo heading text (the deliberately added exercise content), no other pixels changed. The other 2 pages (`categories.png`, `tags.png`) were unflagged (0.000%).
- [x] HTML-source diff (per the program's attribute-diff refinement): confirmed the only markup delta versus baseline is the addition of `data-lottie-hover="false"` on the two demos that don't set `hover` (intended — a default now actually applying, functionally inert per the JS reader) and the new third demo's markup; the second demo's explicit `autoplay=false hover=true loop=false` output is byte-for-byte identical to baseline.
- [x] `git diff` reviewed file-by-file; no unrelated changes
- [x] Commit-body landmine check (`git show -s --format=%B HEAD | grep -E '^-.*-$'`) returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)