### PR TITLE
fix: animations autoplay by default again

### DIFF
--- a/data/structures/animation.yml
+++ b/data/structures/animation.yml
@@ -13,7 +13,10 @@ arguments:
   id:
   class:
   loop:
+  # animations play automatically by default (v5 behavior); the global
+  # autoplay argument defaults to false, which would freeze the default demo
   autoplay:
+    default: true
   hover:
   label:
   mode:


### PR DESCRIPTION
The global autoplay argument defaults to false; under the v6 engine this froze every animation without an explicit autoplay (v5 never applied falsy defaults). Declares the intended default (true) at the structure level. Found in the gethinode.com visual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)