### PR TITLE
fix(shortcodes): give the animation id the UniqueID helper

### DIFF
--- a/layouts/shortcodes/animation.html
+++ b/layouts/shortcodes/animation.html
@@ -25,7 +25,7 @@
 {{ end }}
 
 {{/* Initialize arguments and default values */}}
-{{- $id := or $args.id  (printf "lottie-animation-%d" .Ordinal) -}}
+{{- $id := or $args.id (partial "utilities/UniqueID.html" (dict "prefix" "lottie-animation")) -}}
 {{- $modes := site.Params.main.modes | default (slice "light" "dark") -}}
 {{- $data := or $args.animationData $args.data -}}
 {{- if not $data -}}


### PR DESCRIPTION
The `animation` shortcode built its id from `.Ordinal`, which resets to 0 inside the `example` shortcode's embedded `RenderString`. So two animations in two `{{< example >}}` blocks collided on `lottie-animation-0`. It now uses mod-utils' `UniqueID` helper (`lottie-animation-UID-<n>`, from a per-page counter). The explicit `id` argument still overrides.

Part of an ecosystem-wide `.Ordinal`→UniqueID migration; independent of the companion PRs (mod-utils v6.5.0, which provides the helper, is already released and pinned here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)