### PR TITLE
fix: attribute diagnostic warnings to the intrinsic page (render-once)

### DIFF
--- a/layouts/shortcodes/animation.html
+++ b/layouts/shortcodes/animation.html
@@ -18,7 +18,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($result.errmsg | append $result.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $result.err }}
@@ -33,7 +33,7 @@
         "partial"  "shortcodes/animation.html" 
         "msg"      "Invalid arguments"
         "details"  (slice "Missing argument 'animation-data'")
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{- $error = true -}}


### PR DESCRIPTION
Render-once backlog: diagnostics-only sweep — warning attribution moves to the intrinsic page where one is in scope; zero output-byte effect (combined six-module replacement gate: fully byte-identical run-vs-run, WARN parity, 98/26/24, 0 ERROR; replacement-artifact diffs control-attributed). Module suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)