### PR TITLE
fix: register the lottie module when the animation shortcode renders

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.110.0"
+    min = "0.146.0"
     max = ""
   [[module.imports]]
     path = "github.com/airbnb/lottie-web"

--- a/layouts/shortcodes/animation.html
+++ b/layouts/shortcodes/animation.html
@@ -59,6 +59,9 @@
 
 <!-- Main code -->
 {{- if not $error -}}
+    {{/* Register the lottie module as a page dependency, so the page's script handler includes
+         its assets without requiring `modules = ["lottie"]` in front matter. */}}
+    {{- partial "utilities/AddModule.html" (dict "page" .Page "module" "lottie") -}}
     {{/*
         The "autoplay" argument always carries a schema default of false, so it is never nil by
         the time it reaches here. Only fall back to the deprecated "auto" argument when the


### PR DESCRIPTION
The `animation` shortcode rendered its container but shipped no lottie JS unless the page set front-matter `modules = ["lottie"]`. The shortcode now self-registers via `utilities/AddModule.html` (mod-utils v6.6.2 already imported). Chore: `hugoVersion.min` → 0.146.0.

Evidence (js-pipeline program J5): bare-vs-control page proof on a hinode v3.6.2 exampleSite, zero build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)